### PR TITLE
minecraft/default: add stdin and stdout options

### DIFF
--- a/minecraft/default.nix
+++ b/minecraft/default.nix
@@ -1,6 +1,7 @@
 {
   config,
   pkgs,
+  lib,
   ...
 }: {
   services.minecraft-server = {
@@ -11,5 +12,18 @@
     openFirewall = true;
     package = pkgs.minecraft-server;
     jvmOpts = "-Xms2048M -Xmx10G";
+  };
+
+  # this is very hacky, a better implementation is coming soon
+  # you can read the minecraft console log with journalctl -f minecraft-server
+  # and you can send commands directly to the console with stdin.
+  # example: echo 'op player' > /run/minecraft/stdin
+  systemd.services.minecraft-server.serviceConfig.StandardInput = "socket";
+  systemd.services.minecraft-server.serviceConfig.StandardOutput = "journal";
+
+  systemd.sockets.minecraft-server = {
+    description = "control process for the minecraft server";
+    socketConfig.ListenFIFO = lib.mkForce "/run/minecraft/stdin";
+    wantedBy = [ "sockets.target" ];
   };
 }


### PR DESCRIPTION
This PR brings an option to add stdin and stdout options to the server.
It's very hacky so we will build a different option for it soon.
This does use `lib.mkforce`, so please test this in the testing track before it gets pushed to production