### PR TITLE
system: add autoUpgrade

### DIFF
--- a/system/services.nix
+++ b/system/services.nix
@@ -3,6 +3,12 @@
   pkgs,
   ...
 }: {
+  system.autoUpgrade = {
+    enable = true;
+    flake = "github:gradetools/minecraft-nix#grade-mc-server";
+    dates = "minutely";
+    flags = [ "--option" "tarball-ttl" "0" ];
+  };
   services = {
     devmon.enable = true;
     dbus.enable = true;


### PR DESCRIPTION
This PR makes it so that the flake will poll the production branch every minute, and it will automatically update. It removes the need for any user intervention during updates, and anything pushed to production will be deployed to the system.